### PR TITLE
E_EEPROM erasing failed when installing Flash protection

### DIFF
--- a/source/xmc4_e_eeprom.c
+++ b/source/xmc4_e_eeprom.c
@@ -633,7 +633,8 @@ static E_EEPROM_XMC4_STATUS_t E_EEPROM_XMC4_lInitEraseStateMachine(void)
                 XMC_FLASH_ClearStatus();
                 XMC_FLASH_EraseSector((uint32_t*)sector_start_addr);
 
-                if (XMC_FLASH_GetStatus() != (uint32_t)XMC_FLASH_STATUS_ERASE_STATE)
+                //if (XMC_FLASH_GetStatus() != (uint32_t)XMC_FLASH_STATUS_ERASE_STATE)
+                if ((XMC_FLASH_GetStatus() & FLASH_FSR_ERASE_Msk) != (uint32_t)XMC_FLASH_STATUS_ERASE_STATE)
                 {
                     status = E_EEPROM_XMC4_STATUS_ERASE_ERROR;
                     break;


### PR DESCRIPTION
Hardware:
XMC4800

What happened?
First of all, flash protection is installed.Protect temporary disabling when operating E_EPROM,I found that calling the E_EEPROM_XMC4_lInitEraseStateMachine() to erase failed.The reason is that judging the ERASE bit of FSR register failed,
But actually EARSE bit is set to 1.I think the problem lies in the judgment conditions, as shown in the following figure:
![image](https://github.com/user-attachments/assets/9f039c43-dafb-4f03-8b79-678d2ec0b9e3)
It can be seen from this judgment condition that erasing is successful only when the value of FSR register is equal to 0x20, but RPRODIS bit will be set when Flash protect is temporarily disabled, as shown in the following figure:
![image](https://github.com/user-attachments/assets/85d06f43-3e97-46c8-b627-1408780e0b81)
In this way, it will be judged as a failure, but in fact, it is a success. Therefore, I think it will be more reasonable to modify the judgment condition to the following.
![image](https://github.com/user-attachments/assets/4248d801-11b1-4b89-b991-245bfb07bea3)
Looking forward to hearing from you.